### PR TITLE
Add JsonPath matcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/gomega v1.33.0
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.26.2
+	k8s.io/client-go v0.26.2
 	k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5
 	sigs.k8s.io/controller-runtime v0.14.4
 )
@@ -53,7 +54,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.2 // indirect
-	k8s.io/client-go v0.26.2 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230228151317-19cbebb19cb7 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -784,4 +784,20 @@ var _ = Describe("Matchers", func() {
 			)
 		})
 	})
+
+	When("we match using JsonPath", func() {
+		It("should match on some standard kubernetes objects", func() {
+			deploy := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(3),
+				},
+			}
+			Expect(deploy).To(HaveJsonPath("spec.replicas", "3"))
+			Expect(deploy).NotTo(HaveJsonPath("spec.replicas", "2"))
+			Expect(deploy).NotTo(HaveJsonPath(".imaginary"))
+		})
+	})
 })


### PR DESCRIPTION
JsonPath matcher mirrors the functionality of kubectl's wait jsonpath matching on kubernetes objects

:fire: :fire: :fire: :fire: 